### PR TITLE
Harvesters under 50% of their HP will slowly self-repair back to 50% 

### DIFF
--- a/TIBERIANDAWN/UNIT.CPP
+++ b/TIBERIANDAWN/UNIT.CPP
@@ -428,7 +428,7 @@ void UnitClass::AI(void)
 	**	the heal logic here.
 	*/
 	//Rafael: Harvester should also heal itself like in later games
-	if ((*this == UNIT_HTANK || *this == UNIT_HARVESTER) && (Frame % 16) == 0 && Health_Ratio() < 0x0080) {
+	if ((*this == UNIT_HTANK || *this == UNIT_HARVESTER && PlayerPtr->Difficulty == DIFF_EASY) && (Frame % 16) == 0 && Health_Ratio() < 0x0080) {
 		Strength++;
 		Mark(MARK_CHANGE);
 	}

--- a/TIBERIANDAWN/UNIT.CPP
+++ b/TIBERIANDAWN/UNIT.CPP
@@ -427,7 +427,8 @@ void UnitClass::AI(void)
 	**	If this is a vehicle that heals itself (e.g., Mammoth Tank), then it will perform
 	**	the heal logic here.
 	*/
-	if (*this == UNIT_HTANK && (Frame % 16) == 0 && Health_Ratio() < 0x0080) {
+	//Rafael: Harvester should also heal itself like in later games
+	if ((*this == UNIT_HTANK || *this == UNIT_HARVESTER) && (Frame % 16) == 0 && Health_Ratio() < 0x0080) {
 		Strength++;
 		Mark(MARK_CHANGE);
 	}


### PR DESCRIPTION
TD doesn't seem to have a 'self-repair' attribute for units so I'm just adding to the Mammoth Tank if check